### PR TITLE
ArgumentCountError in  AbstractListTypeToCTypeUpdate.php

### DIFF
--- a/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
+++ b/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
@@ -25,9 +25,9 @@ abstract class AbstractListTypeToCTypeUpdate implements UpgradeWizardInterface
 
     private ConnectionPool $connectionPool;
 
-    public function __construct(ConnectionPool $connectionPool)
+    public function __construct(ConnectionPool $connectionPool = null)
     {
-        $this->connectionPool = $connectionPool;
+        $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
         $this->validateRequirements();
     }
 

--- a/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
+++ b/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
@@ -25,7 +25,7 @@ abstract class AbstractListTypeToCTypeUpdate implements UpgradeWizardInterface
 
     private ConnectionPool $connectionPool;
 
-    public function __construct(ConnectionPool $connectionPool = null)
+    public function __construct(?ConnectionPool $connectionPool = null)
     {
         $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
         $this->validateRequirements();

--- a/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
+++ b/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
@@ -23,11 +23,15 @@ abstract class AbstractListTypeToCTypeUpdate implements UpgradeWizardInterface
     protected const TABLE_CONTENT = 'tt_content';
     protected const TABLE_BACKEND_USER_GROUPS = 'be_groups';
 
-    private ConnectionPool $connectionPool;
+    private ?ConnectionPool $connectionPool = null;
 
-    public function __construct(ConnectionPool $connectionPool = null)
+    public function injectConnectionPool(ConnectionPool $connectionPool): void
     {
-        $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
+        $this->connectionPool = $connectionPool;
+    }
+
+    public function __construct()
+    {
         $this->validateRequirements();
     }
 

--- a/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
+++ b/Classes/Upgrades/AbstractListTypeToCTypeUpdate.php
@@ -23,15 +23,11 @@ abstract class AbstractListTypeToCTypeUpdate implements UpgradeWizardInterface
     protected const TABLE_CONTENT = 'tt_content';
     protected const TABLE_BACKEND_USER_GROUPS = 'be_groups';
 
-    private ?ConnectionPool $connectionPool = null;
+    private ConnectionPool $connectionPool;
 
-    public function injectConnectionPool(ConnectionPool $connectionPool): void
+    public function __construct(ConnectionPool $connectionPool = null)
     {
-        $this->connectionPool = $connectionPool;
-    }
-
-    public function __construct()
-    {
+        $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
         $this->validateRequirements();
     }
 


### PR DESCRIPTION
hi @linawolf 

thanks for the wizard it saves me a lot of upgrade time :) 
I wanted to use it directly in TYPO3 11 (before the upcoming update to 12). But then I got the following error,

(I deleted all caches including composer dump, unfortunately only the code customisation helped)

```
(1/1) ArgumentCountError
Too few arguments to function Linawolf\ListTypeMigration\Upgrades\AbstractListTypeToCTypeUpdate::__construct(), 0 passed in /var/www/html/public/typo3/sysext/core/Classes/Utility/GeneralUtility.php on line 3215 and exactly 1 expected
```